### PR TITLE
Add interest based expiration to CTxMemPool::removeExpired

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -261,15 +261,20 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
     }
 }
 
+int32_t komodo_validate_interest(const CTransaction &tx,int32_t txheight,uint32_t nTime,int32_t dispflag);
+
 void CTxMemPool::removeExpired(unsigned int nBlockHeight)
 {
+    CBlockIndex *tipindex;
     // Remove expired txs from the mempool
     LOCK(cs);
     list<CTransaction> transactionsToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
     {
         const CTransaction& tx = it->GetTx();
-        if (IsExpiredTx(tx, nBlockHeight)) {
+        tipindex = chainActive.Tip();
+        if (IsExpiredTx(tx, nBlockHeight) || (tipindex != 0 && komodo_validate_interest(tx,tipindex->nHeight+1,tipindex->GetMedianTimePast() + 777,1)) < 0)
+        {
             transactionsToRemove.push_back(tx);
         }
     }
@@ -279,6 +284,7 @@ void CTxMemPool::removeExpired(unsigned int nBlockHeight)
         LogPrint("mempool", "Removing expired txid: %s\n", tx.GetHash().ToString());
     }
 }
+
 
 /**
  * Called when a block is connected. Removes from mempool and updates the miner fee estimator.


### PR DESCRIPTION
This fix will remove from the mempool tx that wouldn’t current be
accepted into the mempool. Useful when some old mempool entries keep
getting restored.