### PR TITLE
fix z_mergetoaddress rpc call

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4798,9 +4798,9 @@ UniValue z_mergetoaddress(const UniValue& params, bool fHelp)
     
     if (useAnySprout || useAnySapling || zaddrs.size() > 0) {
         // Get available notes
-        std::vector<CSproutNotePlaintextEntry> sproutEntries;
-        std::vector<SaplingNoteEntry> saplingEntries;
-        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, zaddrs);
+        std::vector<CSproutNotePlaintextEntry> sproutEntries,skipsprout;
+        std::vector<SaplingNoteEntry> saplingEntries,skipsapling;
+        pwalletMain->GetFilteredNotes(sproutEntries, useAnySprout == 0 ? saplingEntries : skipsapling, zaddrs);
         
         // If Sapling is not active, do not allow sending from a sapling addresses.
         if (!saplingActive && saplingEntries.size() > 0) {


### PR DESCRIPTION
now ANY_SPROUT and ANY_SAPLING params if it passed in fromaddresses
processed correctly.