### PR TITLE
fix forced rescan for ZEX and KMD with ztx in wallet

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -468,7 +468,9 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> wtx;
             CValidationState state;
             auto verifier = libzcash::ProofVerifier::Strict();
-            if (!(CheckTransaction(0,wtx, state, verifier) && (wtx.GetHash() == hash) && state.IsValid()))
+            // ac_public chains set at height like KMD and ZEX, will force a rescan if we dont ignore this error: bad-txns-acpublic-chain
+            // there cannot be any ztx in the wallet on ac_public chains that started from block 1, so this wont affect those. 
+            if ( !(CheckTransaction(0,wtx, state, verifier) && (wtx.GetHash() == hash) && state.IsValid()) && (state.GetRejectReason() != "bad-txns-acpublic-chain") )
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
based on: https://github.com/jl777/komodo/commit/566d101d31cedce3c8b91f76eafd99964270a4da

ignore bad-txns-acpublic-chain errors in case of z-tx in the wallet in
the public chains.